### PR TITLE
fix: override template slots when slot children are empty/undefined

### DIFF
--- a/src/SlotContext.tsx
+++ b/src/SlotContext.tsx
@@ -25,6 +25,8 @@ export type SlotContextType = {
   setSlotValue: (name: string, children: SlotChildren) => void;
   /** Removes a named slot and its content */
   removeSlotValue: (name: string) => void;
+  /** Checks if a slot with the given name exists */
+  hasSlot: (name: string) => boolean;
 };
 
 /**
@@ -50,8 +52,7 @@ export const SlotProvider = ({
   const setSlotValue = (name: string, children: SlotChildren) => {
     setSlotValues((prev) => {
       // If content hasn't changed, return same object to prevent re-renders
-      if (prev[name] === children) return prev;
-
+      if (name in prev && prev[name] === children) return prev;
       return {
         ...prev,
         [name]: children,
@@ -70,12 +71,18 @@ export const SlotProvider = ({
     });
   };
 
+  /** Checks if a slot with the given name exists */
+  const hasSlot = (name: string): boolean => {
+    return name in slotValues;
+  };
+
   return (
     <SlotContext.Provider
       value={{
         slotValues,
         setSlotValue,
         removeSlotValue,
+        hasSlot,
       }}
     >
       {children}

--- a/src/TemplateSlot.tsx
+++ b/src/TemplateSlot.tsx
@@ -22,11 +22,11 @@ export const TemplateSlot = ({
   name,
   children,
 }: TemplateSlotProps): JSX.Element => {
-  const { slotValues } = useSlotContext();
+  const { slotValues, hasSlot } = useSlotContext();
   const slotContent = slotValues[name];
 
   // If no slot content, render default children
-  if (!slotContent) {
+  if (!hasSlot(name)) {
     return <>{children}</>;
   }
 

--- a/src/tests/Slot.test.tsx
+++ b/src/tests/Slot.test.tsx
@@ -170,12 +170,13 @@ describe("Integration Tests", () => {
         <Slot name="main">
           <div>Custom Main Content</div>
         </Slot>
+        <Slot name="footer" />
       </DocPageTemplate>,
     );
 
     expect(screen.getByText("Custom Header")).toBeInTheDocument();
     expect(screen.getByText("Custom Main Content")).toBeInTheDocument();
-    expect(screen.getByText("Default Footer")).toBeInTheDocument();
+    expect(screen.queryByText("Default Footer")).not.toBeInTheDocument();
     expect(screen.queryByText("Default Header")).not.toBeInTheDocument();
     expect(screen.queryByText("Default Main Content")).not.toBeInTheDocument();
   });

--- a/src/tests/SlotContext.test.tsx
+++ b/src/tests/SlotContext.test.tsx
@@ -70,6 +70,76 @@ describe("SlotContext", () => {
       expect("footer" in result.current.slotValues).toBe(true);
     });
 
+    describe("hasSlot", () => {
+      const wrapper = ({ children }: { children: ReactNode }) => (
+        <SlotProvider>{children}</SlotProvider>
+      );
+
+      it("should correctly identify existing slots", () => {
+        const { result } = renderHook(() => useSlotContext(), { wrapper });
+
+        act(() => {
+          result.current.setSlotValue("header", <div>Header Content</div>);
+        });
+
+        expect(result.current.hasSlot("header")).toBe(true);
+        expect(result.current.hasSlot("footer")).toBe(false);
+      });
+
+      it("should return false for nonexistent slots", () => {
+        const { result } = renderHook(() => useSlotContext(), { wrapper });
+        expect(result.current.hasSlot("nonexistent")).toBe(false);
+      });
+
+      it("should correctly update after adding and removing slots", () => {
+        const { result } = renderHook(() => useSlotContext(), { wrapper });
+
+        // Initially slot doesn't exist
+        expect(result.current.hasSlot("dynamic")).toBe(false);
+
+        // Add the slot
+        act(() => {
+          result.current.setSlotValue("dynamic", <span>Dynamic content</span>);
+        });
+        expect(result.current.hasSlot("dynamic")).toBe(true);
+
+        // Remove the slot
+        act(() => {
+          result.current.removeSlotValue("dynamic");
+        });
+        expect(result.current.hasSlot("dynamic")).toBe(false);
+      });
+
+      it("should handle null and undefined slot values", () => {
+        const { result } = renderHook(() => useSlotContext(), { wrapper });
+
+        act(() => {
+          result.current.setSlotValue("nullSlot", null);
+          result.current.setSlotValue("undefinedSlot", undefined);
+        });
+
+        expect(result.current.hasSlot("nullSlot")).toBe(true);
+        expect(result.current.hasSlot("undefinedSlot")).toBe(true);
+      });
+
+      it("should be consistent with slotValues object keys", () => {
+        const { result } = renderHook(() => useSlotContext(), { wrapper });
+
+        act(() => {
+          result.current.setSlotValue("test1", "value1");
+          result.current.setSlotValue("test2", "value2");
+        });
+
+        // Check that hasSlot matches what's in slotValues
+        const slotValues = Object.keys(result.current.slotValues);
+        for (const key of slotValues) {
+          expect(result.current.hasSlot(key)).toBe(true);
+        }
+
+        expect(result.current.hasSlot("nonexistentKey")).toBe(false);
+      });
+    });
+
     describe("state optimizations", () => {
       it("should reuse state object when setting same content", () => {
         const { result } = renderHook(() => useSlotContext(), { wrapper });


### PR DESCRIPTION
When a Slot is provided within a SlotProvider with no children, it will override any TemplateSlot children and essentially hide it.

